### PR TITLE
Rewrite of `logging_procedure_test` and CI implementation (for OCaml)

### DIFF
--- a/.github/workflows/test-ocaml-ci.yml
+++ b/.github/workflows/test-ocaml-ci.yml
@@ -1,0 +1,95 @@
+name: Test
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - '**.el'
+      - 'media/**'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - '**.el'
+      - 'media/**'
+
+jobs:
+
+  build-and-test:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest ]
+        ocaml-compiler: [ ocaml-base-compiler.5.3.0 ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Tree
+        uses: actions/checkout@v4
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: |
+          opam install . --deps-only --with-test
+          opam exec -- dune build
+          opam exec -- dune runtest
+
+  lint-doc:
+    build-and-test:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest ]
+        ocaml-compiler: [ ocaml-base-compiler.5.3.0 ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Tree
+        uses: actions/checkout@v4
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - uses: ocaml/setup-ocaml/lint-doc@v3
+
+  lint-fmt:
+    build-and-test:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest ]
+        ocaml-compiler: [ ocaml-base-compiler.5.3.0 ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Tree
+        uses: actions/checkout@v4
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - uses: ocaml/setup-ocaml/lint-fmt@v3
+
+  lint-opam:
+    build-and-test:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest ]
+        ocaml-compiler: [ ocaml-base-compiler.5.3.0 ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Tree
+        uses: actions/checkout@v4
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - uses: ocaml/setup-ocaml/lint-opam@v3

--- a/test/server/util.ml
+++ b/test/server/util.ml
@@ -41,14 +41,7 @@ let request ~id ?params meth =
   request_input ~id:i ?params meth
 ;;
 
-let step
-      (module H : Kohai_core.Eff.HANDLER)
-      ?should_fail
-      ?(desc = "No description")
-      ~id
-      callback
-  =
-  let _ = desc in
+let step (module H : Kohai_core.Eff.HANDLER) ?should_fail ~id callback =
   let req = callback (module H : Kohai_core.Eff.HANDLER) ~id () in
   print_result ?should_fail req
 ;;

--- a/test/server/util.mli
+++ b/test/server/util.mli
@@ -12,7 +12,6 @@ val print_result
 val step
   :  (module Kohai_core.Sigs.EFFECT_HANDLER)
   -> ?should_fail:bool
-  -> ?desc:string
   -> id:int ref
   -> ((module Kohai_core.Sigs.EFFECT_HANDLER)
       -> id:int ref


### PR DESCRIPTION
A preliminary work to be able to contribute to the existing code 
more serenely.

### First commit:

Initiating the handler and file system at the top-level of the test
module (`logging_test_procedure_test`) allows you to separate the
various stages of the test scenario into tests with different
expectations, which has several benefits:

- The code is more readable overall the test is broken down into
- several `structure_items`, making the code easier to type step by
  step (and making it easier to observe the module).

### Second commit:

The second commit sets up a CI for testing (to encourage external 
contribution).